### PR TITLE
remove Zappa

### DIFF
--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -3,4 +3,3 @@ flake8==3.8.4
 flake8-isort==4.0.0
 nose==1.3.7
 parameterized==0.7.1
-zappa==0.48.2


### PR DESCRIPTION
Currently, deploy to not AWS Lambda but CloudRun. So it is not needed
anymore.